### PR TITLE
Implement artist bounded context use cases test

### DIFF
--- a/artist/src/main/kotlin/ArtistApplicationService.kt
+++ b/artist/src/main/kotlin/ArtistApplicationService.kt
@@ -23,7 +23,7 @@ class ArtistApplicationService {
         return VocaloidId("1")
     }
 
-    fun presentNewVocaloidSong(artistId: ArtistId, vocaloidId: VocaloidId, title: String, explain: String, sourceLink: String): MusicId {
+    fun presentNewMusicWithVocaloid(artistId: ArtistId, vocaloidId: VocaloidId, title: String, explain: String, sourceLink: String): MusicId {
         return MusicId("1")
     }
 }

--- a/artist/src/main/kotlin/ArtistApplicationService.kt
+++ b/artist/src/main/kotlin/ArtistApplicationService.kt
@@ -1,7 +1,31 @@
 class ArtistApplicationService {
-    fun enrollNewArtist(name: String) {}
+    fun enrollNewArtist(name: String): ArtistId {
+        return ArtistId("1")
+    }
 
     fun searchByName(name: String): ArtistId {
         return ArtistId("1")
+    }
+
+    fun changeName(id: ArtistId, newName: String) {}
+
+    fun presentNewMusic(artistId: ArtistId, title: String, explain: String, sourceLink: String): MusicId {
+        return MusicId("1")
+    }
+
+    fun presentNewMusicWithSeveralArtist(artistList: List<ArtistId>, title: String, explain: String, sourceLink: String): MusicId {
+        return MusicId("1")
+    }
+
+    fun presentNewMusicWithFeaturing(artistId: ArtistId, featuringArtistIdList: List<ArtistId>, title: String, explain: String, sourceLink: String): MusicId {
+        return MusicId("1")
+    }
+
+    fun enrollNewVocaloid(name: String): VocaloidId {
+        return VocaloidId("1")
+    }
+
+    fun presentNewVocaloidSong(artistId: ArtistId, vocaloidId: VocaloidId, title: String, explain: String, sourceLink: String): MusicId {
+        return MusicId("1")
     }
 }

--- a/artist/src/main/kotlin/ArtistApplicationService.kt
+++ b/artist/src/main/kotlin/ArtistApplicationService.kt
@@ -1,7 +1,5 @@
 class ArtistApplicationService {
-    fun enrollNewArtist(name: String): ArtistId {
-        return ArtistId("1")
-    }
+    fun enrollNewArtist(name: String) {}
 
     fun searchByName(name: String): ArtistId {
         return ArtistId("1")

--- a/artist/src/main/kotlin/MusicId.kt
+++ b/artist/src/main/kotlin/MusicId.kt
@@ -1,0 +1,1 @@
+data class MusicId(val id: String)

--- a/artist/src/main/kotlin/NotFoundArtistByName.kt
+++ b/artist/src/main/kotlin/NotFoundArtistByName.kt
@@ -1,0 +1,1 @@
+class NotFoundArtistByName(artistName:String): Exception("can't found artist using name: $artistName")

--- a/artist/src/main/kotlin/VocaloidId.kt
+++ b/artist/src/main/kotlin/VocaloidId.kt
@@ -1,0 +1,1 @@
+data class VocaloidId(val id: String)

--- a/artist/src/test/kotlin/ArtistApplicationService.kt
+++ b/artist/src/test/kotlin/ArtistApplicationService.kt
@@ -8,13 +8,157 @@ object ArtistApplicationServiceFeature : Spek({
         val applicationService by memoized { ArtistApplicationService() }
 
         Scenario("enroll new artist") {
+            lateinit var createdArtistId: ArtistId
+
             When("enroll michael jackson") {
-                applicationService.enrollNewArtist("michael jackson")
+                createdArtistId = applicationService.enrollNewArtist("michael jackson")
             }
 
             Then("it can find artist id using name") {
-                val artistId = applicationService.searchByName("michael jackson")
-                expectThat(artistId).isA<ArtistId>()
+                expectThat(createdArtistId).isA<ArtistId>()
+            }
+        }
+
+        Scenario("change artist name") {
+            lateinit var targetArtistId: ArtistId
+
+            val enrolledName = "michael jackson"
+            val newName = "Las"
+
+            Given("already enrolled artist") {
+                targetArtistId = applicationService.enrollNewArtist(enrolledName)
+            }
+
+            When("change artist name to '$newName'") {
+                applicationService.changeName(targetArtistId, newName)
+            }
+
+            Then("it can find artist id using new name('$newName').") {
+                val artistId = applicationService.searchByName(newName)
+                expectThat(artistId)
+                        .isA<ArtistId>()
+                        .isEqualTo(targetArtistId)
+            }
+
+            Then("it can't find artist id using before name('$enrolledName')") {
+//                 TODO: uncomment this assertion.
+//                expectCatching { applicationService.searchByName(enrolledName) }
+//                        .isFailure()
+//                        .isA<NotFoundArtistByName>()
+            }
+        }
+
+        Scenario("artist present new music") {
+            lateinit var artistId: ArtistId
+            lateinit var newMusicId: MusicId
+
+            val artistName = "michael jackson"
+            val title = "Billie Jean"
+            val explain = "Billie Jean is a song in my first album."
+            val sourceLink = "https://www.youtube.com/watch?v=Zi_XLOBDo_Y"
+
+            Given("enroll artist('$artistName')") {
+                artistId = applicationService.enrollNewArtist(artistName)
+            }
+
+            When("present new music('$title')") {
+                newMusicId = applicationService.presentNewMusic(artistId, title, explain, sourceLink)
+            }
+
+            Then("return new music id") {
+                expectThat(newMusicId).isA<MusicId>()
+            }
+        }
+
+        Scenario("several artist present new music") {
+            lateinit var artistList: List<ArtistId>
+            lateinit var createdMusicId: MusicId
+
+            val title = "Cooler Than the Cool"
+            val explain = "Cooler Than the Cool은 4 the youth에 포함된 노래입니다."
+            val sourceLink = "https://www.youtube.com/watch?v=myHhpAKor70"
+
+            Given("enroll artist('JUSTHIS', 'Paloalto')") {
+                val firstArtistId = applicationService.enrollNewArtist("JUSTHIS")
+                val secondArtistId = applicationService.enrollNewArtist("Paloalto")
+                artistList = listOf(firstArtistId, secondArtistId)
+            }
+
+            When("present new music with several artist") {
+                createdMusicId = applicationService.presentNewMusicWithSeveralArtist(
+                        artistList,
+                        title,
+                        explain,
+                        sourceLink
+                )
+            }
+
+            Then("it can find artist id using name") {
+                expectThat(createdMusicId).isA<MusicId>()
+            }
+        }
+
+        Scenario("artist present new music with other artist featuring") {
+            lateinit var artistId: ArtistId
+            lateinit var featuringArtistIdList: List<ArtistId>
+            lateinit var newMusicId: MusicId
+
+            val artistName = "JUSTHIS"
+            val title = "Cooler Than the Cool"
+            val explain = "Cooler Than the Cool은 4 the youth에 포함된 노래입니다."
+            val sourceLink = "https://www.youtube.com/watch?v=myHhpAKor70"
+
+            Given("enroll artist and featuring artist") {
+                artistId = applicationService.enrollNewArtist(artistName)
+                val featuringArtistId = applicationService.enrollNewArtist("Huckleberry P")
+                featuringArtistIdList = listOf(featuringArtistId)
+            }
+
+            When("present new music('$title') with featuring artist") {
+                newMusicId = applicationService.presentNewMusicWithFeaturing(
+                        artistId,
+                        featuringArtistIdList,
+                        title,
+                        explain,
+                        sourceLink
+                )
+            }
+
+            Then("return new music id") {
+                expectThat(newMusicId).isA<MusicId>()
+            }
+        }
+
+        Scenario("artist present new music that using vocaloid") {
+            lateinit var artistId: ArtistId
+            lateinit var newMusicId: MusicId
+            lateinit var vocaloidId: VocaloidId
+
+            val artistName = "Omoi"
+            val title = "Teo"
+            val explain = "Teo is an exciting band-type song."
+            val sourceLink = "https://www.youtube.com/watch?v=bmkY2yc1K7Q"
+
+            Given("enroll artist") {
+                artistId = applicationService.enrollNewArtist(artistName)
+            }
+
+            Given("enroll vocaloid") {
+                vocaloidId = applicationService.enrollNewVocaloid("Hatsune Miku")
+            }
+
+            When("present new vocaloid music") {
+                newMusicId = applicationService.presentNewVocaloidSong(
+                        artistId,
+                        vocaloidId,
+                        title,
+                        explain,
+                        sourceLink
+                )
+            }
+
+            Then("return new music id") {
+                expectThat(newMusicId).isA<MusicId>()
             }
         }
     }

--- a/artist/src/test/kotlin/ArtistApplicationService.kt
+++ b/artist/src/test/kotlin/ArtistApplicationService.kt
@@ -156,7 +156,7 @@ object ArtistApplicationServiceFeature : Spek({
             }
 
             When("present new vocaloid music") {
-                newMusicId = applicationService.presentNewVocaloidSong(
+                newMusicId = applicationService.presentNewMusicWithVocaloid(
                         artistId,
                         vocaloidId,
                         title,

--- a/artist/src/test/kotlin/ArtistApplicationService.kt
+++ b/artist/src/test/kotlin/ArtistApplicationService.kt
@@ -8,13 +8,13 @@ object ArtistApplicationServiceFeature : Spek({
         val applicationService by memoized { ArtistApplicationService() }
 
         Scenario("enroll new artist") {
-            lateinit var createdArtistId: ArtistId
 
             When("enroll michael jackson") {
-                createdArtistId = applicationService.enrollNewArtist("michael jackson")
+                applicationService.enrollNewArtist("michael jackson")
             }
 
             Then("it can find artist id using name") {
+                val createdArtistId = applicationService.searchByName("michael jackson")
                 expectThat(createdArtistId).isA<ArtistId>()
             }
         }
@@ -26,14 +26,15 @@ object ArtistApplicationServiceFeature : Spek({
             val newName = "Las"
 
             Given("already enrolled artist") {
-                targetArtistId = applicationService.enrollNewArtist(enrolledName)
+                applicationService.enrollNewArtist(enrolledName)
+                targetArtistId = applicationService.searchByName(enrolledName)
             }
 
-            When("change artist name to '$newName'") {
+            When("artist change name to others") {
                 applicationService.changeName(targetArtistId, newName)
             }
 
-            Then("it can find artist id using new name('$newName').") {
+            Then("it can find artist id using new name") {
                 val artistId = applicationService.searchByName(newName)
                 expectThat(artistId)
                         .isA<ArtistId>()
@@ -57,11 +58,12 @@ object ArtistApplicationServiceFeature : Spek({
             val explain = "Billie Jean is a song in my first album."
             val sourceLink = "https://www.youtube.com/watch?v=Zi_XLOBDo_Y"
 
-            Given("enroll artist('$artistName')") {
-                artistId = applicationService.enrollNewArtist(artistName)
+            Given("artist already enrolled") {
+                applicationService.enrollNewArtist(artistName)
+                artistId = applicationService.searchByName(artistName)
             }
 
-            When("present new music('$title')") {
+            When("present new music") {
                 newMusicId = applicationService.presentNewMusic(artistId, title, explain, sourceLink)
             }
 
@@ -78,9 +80,11 @@ object ArtistApplicationServiceFeature : Spek({
             val explain = "Cooler Than the Cool은 4 the youth에 포함된 노래입니다."
             val sourceLink = "https://www.youtube.com/watch?v=myHhpAKor70"
 
-            Given("enroll artist('JUSTHIS', 'Paloalto')") {
-                val firstArtistId = applicationService.enrollNewArtist("JUSTHIS")
-                val secondArtistId = applicationService.enrollNewArtist("Paloalto")
+            Given("both artist already enrolled") {
+                applicationService.enrollNewArtist("JUSTHIS")
+                applicationService.enrollNewArtist("Paloalto")
+                val firstArtistId = applicationService.searchByName("JUSTHIS")
+                val secondArtistId = applicationService.searchByName("Paloalto")
                 artistList = listOf(firstArtistId, secondArtistId)
             }
 
@@ -93,7 +97,7 @@ object ArtistApplicationServiceFeature : Spek({
                 )
             }
 
-            Then("it can find artist id using name") {
+            Then("return new music id") {
                 expectThat(createdMusicId).isA<MusicId>()
             }
         }
@@ -109,8 +113,11 @@ object ArtistApplicationServiceFeature : Spek({
             val sourceLink = "https://www.youtube.com/watch?v=myHhpAKor70"
 
             Given("enroll artist and featuring artist") {
-                artistId = applicationService.enrollNewArtist(artistName)
-                val featuringArtistId = applicationService.enrollNewArtist("Huckleberry P")
+                applicationService.enrollNewArtist(artistName)
+                artistId = applicationService.searchByName(artistName)
+
+                applicationService.enrollNewArtist("Huckleberry P")
+                val featuringArtistId = applicationService.searchByName(artistName)
                 featuringArtistIdList = listOf(featuringArtistId)
             }
 
@@ -140,7 +147,8 @@ object ArtistApplicationServiceFeature : Spek({
             val sourceLink = "https://www.youtube.com/watch?v=bmkY2yc1K7Q"
 
             Given("enroll artist") {
-                artistId = applicationService.enrollNewArtist(artistName)
+                applicationService.enrollNewArtist(artistName)
+                artistId = applicationService.searchByName(artistName)
             }
 
             Given("enroll vocaloid") {


### PR DESCRIPTION
artist bounded context에서 사용하는 use cases들을 구현하였습니다.

현재는 의도적으로 하나의 application service에 많은 메서드가 모여있습니다. IDDD의 경우에는 각각의 application service를 만들게 되어있습니다. 그러나 시나리오를 표현하는 관점에서 다른 서비스로 만들게 되면 하나의 서비스만 테스트 할 수 없고, 선행되어야 하는 메서드에 의존하게 됩니다.

사례를 보자면, music application service와 artist application service가 분리 되어있다고 하면 artist application service에서 enroll artist를 해야만 music application service의 persent new song을 할 수 있습니다. 저는 이러한 부분을 테스트에 녹여내고 싶었기에, 다른 application service로 만들지 않고 하나의 application service를 사용했습니다.

IDDD의 예시에서는 이런 경우에 application service를 테스트 할 때 repository에 직접 save하는 방식을 채용하고 있으나, 현재 우리 프로젝트에서는 REPOSITORY와 같은 존재들이 정의되어있지 않기때문에, 추후에 이 부분은 그대로 두거나 더 불편한 점이 발견된다면 리팩터링 할 예정입니다.

테스트를 통과하기 위하여 Scenario "change artist name"의 assertion을 일부 주석으로 처리해두었습니다. specification형식의 테스트의 경우에는 skip기능이 있지만 gherkin방식의 테스트에서는 skip이 존재하지 않았습니다.

현재 지원하지 않는 몇가지 기능이 있어서 추후 TODO로 남겨두려고 합니다.
- [ ] 특정 artist가 present한 music들을 가져오는 기능
- [ ] 여러 보컬로이드를 사용한 노래도 등록 가능하게 한다
- [ ] 보컬로이드 버전을 표기한다
- [ ] 앨범이라는 개념 추가하기

See Also
  - application service를 테스트 하기 위하여 repository에 접근하는 코드: https://github.com/VaughnVernon/IDDD_Samples/blob/master/iddd_collaboration/src/test/java/com/saasovation/collaboration/application/forum/DiscussionApplicationServiceTest.java#L39